### PR TITLE
Add CAPACITI Placement Portal project and fix name

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,4 +1,3 @@
-
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Menu, X } from "lucide-react";
@@ -40,7 +39,7 @@ const Navigation = ({ activeSection }: NavigationProps) => {
       <div className="container mx-auto px-4">
         <div className="flex justify-between items-center">
           <div className="text-2xl font-bold gradient-text">
-            Tamia Rampy
+            Tamia Ramplin
           </div>
 
           {/* Desktop Navigation */}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -23,32 +23,38 @@ const ProjectCard = ({ project, delay }: ProjectCardProps) => {
   const [showVideo, setShowVideo] = useState(false);
 
   return (
-    <Card 
-      className="glass border-primary/20 hover:border-primary/40 transition-all duration-500 hover:shadow-2xl hover:scale-105 group animate-fade-scale"
+    <Card
+      className="glass border-primary/20 hover:border-primary/40 transition-all duration-500 hover:shadow-2xl hover:scale-105 group animate-fade-scale h-full flex flex-col"
       style={{ animationDelay: `${delay}ms` }}
     >
-      <CardContent className="space-y-4">
+      <CardContent className="flex flex-col h-full p-6">
         {/* Project Title */}
-        <h3 className="text-xl font-semibold text-black mb-2 text-center">{project.title}</h3>
+        <h3 className="text-xl font-semibold text-black mb-4 text-center">{project.title}</h3>
 
         {/* Show video if toggled, otherwise show image */}
-        {project.video && showVideo ? (
-          <video
-            src={project.video}
-            controls
-            autoPlay
-            className="w-full rounded-lg shadow"
-            poster={project.image}
-          />
-        ) : (
-          <img
-            src={project.image}
-            alt={project.title}
-            className="w-full rounded-lg shadow"
-          />
-        )}
+        <div className="mb-4">
+          {project.video && showVideo ? (
+            <video
+              src={project.video}
+              controls
+              autoPlay
+              className="w-full h-48 object-cover rounded-lg shadow"
+              poster={project.image}
+            />
+          ) : (
+            <img
+              src={project.image}
+              alt={project.title}
+              className="w-full h-48 object-cover rounded-lg shadow"
+            />
+          )}
+        </div>
 
-        <div className="flex flex-wrap gap-2">
+        {/* Project Description */}
+        <p className="text-muted-foreground text-sm mb-4 flex-grow">{project.description}</p>
+
+        {/* Technologies */}
+        <div className="flex flex-wrap gap-2 mb-4">
           {project.technologies.map((tech) => (
             <Badge
               key={tech}
@@ -59,8 +65,9 @@ const ProjectCard = ({ project, delay }: ProjectCardProps) => {
             </Badge>
           ))}
         </div>
-        
-        <div className="flex gap-3 pt-4">
+
+        {/* Buttons - Always at bottom */}
+        <div className="flex gap-3 mt-auto">
           <Button
             variant="outline"
             size="sm"

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -38,7 +38,7 @@ const projects = [
     title: "CAPACITI Placement Portal",
     description: "A full-stack job placement platform for graduates, built using React, Firebase, Supabase, and Tailwind CSS. It features user authentication, profile management, CV uploads, job applications, interviews, and real-time placement tracking.",
     technologies: ["React", "TypeScript", "Firebase", "Supabase", "Tailwind CSS"],
-    githubUrl: "https://github.com/TamiaRampy/CAPACITI-Placement-Portal",
+    githubUrl: "https://github.com/Ricky21007/Placement-portal",
     liveUrl: "https://capacitiplacementportal.netlify.app",
     image: "https://cdn.builder.io/api/v1/image/assets%2Fdabfba3b76404070a0a969852649639b%2Ff6e5e749b22c42e897d5c31298906f8f?format=webp&width=800"
   }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -33,6 +33,14 @@ const projects = [
     githubUrl: "https://github.com/aidan2125/Backend-testing",
     liveUrl: "https://aidan2125.github.io/Backend-testing/",
     image: "/Travique.PNG"
+  },
+  {
+    title: "CAPACITI Placement Portal",
+    description: "A full-stack job placement platform for graduates, built using React, Firebase, Supabase, and Tailwind CSS. It features user authentication, profile management, CV uploads, job applications, interviews, and real-time placement tracking.",
+    technologies: ["React", "TypeScript", "Firebase", "Supabase", "Tailwind CSS"],
+    githubUrl: "https://github.com/TamiaRampy/CAPACITI-Placement-Portal",
+    liveUrl: "https://capacitiplacementportal.netlify.app",
+    image: "/placeholder.svg"
   }
 ];
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -40,7 +40,7 @@ const projects = [
     technologies: ["React", "TypeScript", "Firebase", "Supabase", "Tailwind CSS"],
     githubUrl: "https://github.com/TamiaRampy/CAPACITI-Placement-Portal",
     liveUrl: "https://capacitiplacementportal.netlify.app",
-    image: "/placeholder.svg"
+    image: "https://cdn.builder.io/api/v1/image/assets%2Fdabfba3b76404070a0a969852649639b%2Ff6e5e749b22c42e897d5c31298906f8f?format=webp&width=800"
   }
 ];
 


### PR DESCRIPTION
## Purpose
The user requested to add a new project (CAPACITI Placement Portal) to their portfolio page, ensuring it matches the layout and styling of existing projects with consistent card heights. They also wanted to update their professional name from "Tamia Rampy" to "Tamia Ramplin" in the navigation header for a more professional appearance.

## Code changes
- **Navigation**: Updated name from "Tamia Rampy" to "Tamia Ramplin" in the header
- **ProjectCard component**: Enhanced layout with flexbox for consistent card heights, fixed image dimensions (h-48), and improved spacing structure
- **Projects data**: Added new CAPACITI Placement Portal project with description, tech stack (React, TypeScript, Firebase, Supabase, Tailwind CSS), GitHub link, and live demo URL
- **Styling improvements**: Ensured all project cards maintain equal height regardless of content length

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3b9a7ea02a7d4eb7ba343efd6880a379/zen-space)

👀 [Preview Link](https://3b9a7ea02a7d4eb7ba343efd6880a379-zen-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b9a7ea02a7d4eb7ba343efd6880a379</projectId>-->
<!--<branchName>zen-space</branchName>-->