### PR TITLE
Update project grid layout to 2x2 arrangement

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -188,7 +188,7 @@ const Index = () => {
               A showcase of my recent work and personal projects
             </p>
           </div>
-          <div className="grid lg:grid-cols-2 xl:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {projects.map((project, index) => (
               <ProjectCard key={project.title} project={project} delay={index * 200} />
             ))}


### PR DESCRIPTION
## Purpose
The user requested to change the project section layout from displaying 4 projects in a single row to a 2x2 grid arrangement - showing 2 projects on top and the other 2 projects below them.

## Code changes
- Modified the CSS grid classes in the projects section from `lg:grid-cols-2 xl:grid-cols-3` to `grid-cols-1 md:grid-cols-2`
- This creates a responsive layout that shows 1 column on mobile and 2 columns on medium screens and above
- Removed the extra large screen configuration to maintain the 2-column maximum layout

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3b9a7ea02a7d4eb7ba343efd6880a379/zenith-haven)

👀 [Preview Link](https://3b9a7ea02a7d4eb7ba343efd6880a379-zenith-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b9a7ea02a7d4eb7ba343efd6880a379</projectId>-->
<!--<branchName>zenith-haven</branchName>-->